### PR TITLE
Adding public routes

### DIFF
--- a/src/iam/authentication/authentication.controller.ts
+++ b/src/iam/authentication/authentication.controller.ts
@@ -2,7 +2,10 @@ import { Body, Controller, HttpStatus, Post, HttpCode } from '@nestjs/common';
 import { AuthenticationService } from './authentication.service';
 import { SignUpDto } from './dto/sign-up.dto/sign-up.dto';
 import { SignInDto } from './dto/sign-in.dto/sign-in.dto';
+import { AuthType } from './enums/auth-type.enum';
+import { Auth } from './decorators/auth.decorator';
 
+@Auth(AuthType.None)
 @Controller('authentication')
 export class AuthenticationController {
   constructor(private readonly authService: AuthenticationService) {}

--- a/src/iam/authentication/decorators/auth.decorator.ts
+++ b/src/iam/authentication/decorators/auth.decorator.ts
@@ -1,0 +1,7 @@
+import { AuthType } from '../enums/auth-type.enum';
+import { SetMetadata } from '@nestjs/common';
+
+export const AUTH_TYPE_KEY = 'authType';
+
+export const Auth = (...authTypes: AuthType[]) =>
+  SetMetadata(AUTH_TYPE_KEY, authTypes);

--- a/src/iam/authentication/enums/auth-type.enum.ts
+++ b/src/iam/authentication/enums/auth-type.enum.ts
@@ -1,0 +1,4 @@
+export enum AuthType {
+  Bearer,
+  None,
+}

--- a/src/iam/authentication/guards/access-token/access-token.guard.ts
+++ b/src/iam/authentication/guards/access-token/access-token.guard.ts
@@ -30,7 +30,6 @@ export class AccessTokenGuard implements CanActivate {
         this.jwtConfiguration,
       );
       request[REQUEST_USER_KEY] = payload;
-      console.log(payload);
     } catch {
       throw new UnauthorizedException();
     }

--- a/src/iam/authentication/guards/authentication/authentication.guard.spec.ts
+++ b/src/iam/authentication/guards/authentication/authentication.guard.spec.ts
@@ -1,0 +1,7 @@
+import { AuthenticationGuard } from './authentication.guard';
+
+describe('AuthenticationGuard', () => {
+  it('should be defined', () => {
+    expect(new AuthenticationGuard()).toBeDefined();
+  });
+});

--- a/src/iam/authentication/guards/authentication/authentication.guard.ts
+++ b/src/iam/authentication/guards/authentication/authentication.guard.ts
@@ -1,0 +1,48 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AccessTokenGuard } from '../access-token/access-token.guard';
+import { AuthType } from '../../enums/auth-type.enum';
+import { AUTH_TYPE_KEY } from '../../decorators/auth.decorator';
+
+@Injectable()
+export class AuthenticationGuard implements CanActivate {
+  private static readonly defaultAuthType = AuthType.Bearer;
+  private readonly authTypeGuardMap: Record<
+    AuthType,
+    CanActivate | CanActivate[]
+  > = {
+    [AuthType.Bearer]: this.accessTokenGuard,
+    [AuthType.None]: { canActivate: () => true },
+  };
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly accessTokenGuard: AccessTokenGuard,
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const authTypes = this.reflector.getAllAndOverride<AuthType[]>(
+      AUTH_TYPE_KEY,
+      [context.getHandler(), context.getClass()],
+    ) ?? [AuthenticationGuard.defaultAuthType];
+
+    const guards = authTypes.map((type) => this.authTypeGuardMap[type]).flat();
+    let error = new UnauthorizedException();
+
+    for (const instance of guards) {
+      const canActivate = await Promise.resolve(
+        instance.canActivate(context),
+      ).catch((err) => {
+        error = err;
+      });
+
+      if (canActivate) {
+        return true;
+      }
+    }
+    throw error;
+  }
+}

--- a/src/iam/iam.module.ts
+++ b/src/iam/iam.module.ts
@@ -9,6 +9,7 @@ import { JwtModule } from '@nestjs/jwt';
 import jwtConfig from './config/jwt.config';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
+import { AuthenticationGuard } from './authentication/guards/authentication/authentication.guard';
 import { AccessTokenGuard } from './authentication/guards/access-token/access-token.guard';
 
 @Module({
@@ -19,7 +20,9 @@ import { AccessTokenGuard } from './authentication/guards/access-token/access-to
   ],
   providers: [
     { provide: HashingService, useClass: BcryptService },
-    { provide: APP_GUARD, useClass: AccessTokenGuard },
+    // { provide: APP_GUARD, useClass: AccessTokenGuard },
+    { provide: APP_GUARD, useClass: AuthenticationGuard },
+    AccessTokenGuard,
     AuthenticationService,
   ],
   controllers: [AuthenticationController],


### PR DESCRIPTION
There are always certain endpoints that should remain public (e.g. the “**signIn**” endpoint that lets users log in to the system),  unless it’s public, no one would be able to access it and actually “log in”.
As before in the application - every route is being protected by our **AccessTokenGuard** since we registered it globally via **APP_GUARD**. 
Now we let our application know which routes we want to remain public.
To achieve  this,  created a new **_decorator_** that lets us to flag specific endpoints as “**unprotected**”. 