### PR TITLE
Implements Claim based authorization

### DIFF
--- a/src/coffees/coffees.controller.ts
+++ b/src/coffees/coffees.controller.ts
@@ -14,12 +14,15 @@ import { ActiveUser } from '../iam/decorators/active-user.decorator';
 import { ActiveUserData } from '../iam/interfaces/active-user.data';
 import { Roles } from '../iam/authorization/decorators/roles.decorators';
 import { Role } from '../users/enums/role.enum';
+import { Permission } from '../iam/authorization/permission.type';
+import { Permissions } from '../iam/authorization/decorators/permissions.decorator';
 
 @Controller('coffees')
 export class CoffeesController {
   constructor(private readonly coffeesService: CoffeesService) {}
 
-  @Roles(Role.Admin)
+  // @Roles(Role.Admin) // 👈
+  @Permissions(Permission.CreateCoffee) // 👈
   @Post()
   create(@Body() createCoffeeDto: CreateCoffeeDto) {
     return this.coffeesService.create(createCoffeeDto);

--- a/src/coffees/coffees.permission.ts
+++ b/src/coffees/coffees.permission.ts
@@ -1,0 +1,8 @@
+/**
+ * You would store these permissions in a database table, but for the
+ * sake of simplicity we used this enum*/
+export enum CoffeesPermission {
+  CreateCoffee = 'create_coffee',
+  UpdateCoffee = 'update_coffee',
+  DeleteCoffee = 'delete_coffee',
+}

--- a/src/iam/authentication/authentication.service.ts
+++ b/src/iam/authentication/authentication.service.ts
@@ -71,10 +71,13 @@ export class AuthenticationService {
       this.signToken<Partial<ActiveUserData>>(
         user.id,
         this.jwtConfiguration.accessTokenTtl,
-        { email: user.email, role: user.role },
+        {
+          email: user.email,
+          role: user.role,
+          // ⚠️ WARNING
+          permissions: user.permissions, // 👈👈👈
+        },
       ),
-      // Ideally we should add an interface describing the RefreshToken Payload
-      // structure.
       this.signToken(user.id, this.jwtConfiguration.refreshTokenTtl, {
         refreshTokenId,
       }),

--- a/src/iam/authorization/decorators/permissions.decorator.ts
+++ b/src/iam/authorization/decorators/permissions.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { PermissionType } from '../permission.type';
+
+export const PERMISSIONS_KEY = 'permissions';
+export const Permissions = (...permissions: PermissionType[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/src/iam/authorization/guards/permissions/permissions.guard.ts
+++ b/src/iam/authorization/guards/permissions/permissions.guard.ts
@@ -1,0 +1,31 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { PermissionType } from '../../permission.type';
+import { PERMISSIONS_KEY } from '../../decorators/permissions.decorator';
+import { REQUEST_USER_KEY } from '../../../iam.constants';
+import { ActiveUserData } from '../../../interfaces/active-user.data';
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const contextPermissions = this.reflector.getAllAndOverride<
+      PermissionType[]
+    >(PERMISSIONS_KEY, [context.getHandler(), context.getClass()]);
+    if (!contextPermissions) {
+      return true;
+    }
+    const user: ActiveUserData = context.switchToHttp().getRequest()[
+      REQUEST_USER_KEY
+    ];
+    return contextPermissions.every(
+      (
+        permission, // 👈 use of .every() diff than roles guard
+      ) => user.permissions?.includes(permission),
+    );
+  }
+}

--- a/src/iam/authorization/permission.type.ts
+++ b/src/iam/authorization/permission.type.ts
@@ -1,0 +1,10 @@
+import { CoffeesPermission } from '../../coffees/coffees.permission';
+
+export const Permission = {
+  ...CoffeesPermission,
+};
+
+// Export the permission TYPE, so we can use it as an input argument type
+// of the decorator
+
+export type PermissionType = CoffeesPermission; // | ...other permission enums

--- a/src/iam/iam.module.ts
+++ b/src/iam/iam.module.ts
@@ -12,7 +12,8 @@ import { APP_GUARD } from '@nestjs/core';
 import { AuthenticationGuard } from './authentication/guards/authentication/authentication.guard';
 import { AccessTokenGuard } from './authentication/guards/access-token/access-token.guard';
 import { RefreshTokenIdsStorage } from './authentication/refresh-token-ids.storage/refresh-token-ids.storage';
-import { RolesGuard } from './authorization/guards/roles/roles.guard';
+// import { RolesGuard } from './authorization/guards/roles/roles.guard';
+import { PermissionsGuard } from './authorization/guards/permissions/permissions.guard';
 
 @Module({
   imports: [
@@ -24,7 +25,7 @@ import { RolesGuard } from './authorization/guards/roles/roles.guard';
     { provide: HashingService, useClass: BcryptService },
     // { provide: APP_GUARD, useClass: AccessTokenGuard },
     { provide: APP_GUARD, useClass: AuthenticationGuard },
-    { provide: APP_GUARD, useClass: RolesGuard },
+    { provide: APP_GUARD, useClass: PermissionsGuard }, // RolesGuard },
     AccessTokenGuard,
     RefreshTokenIdsStorage,
     AuthenticationService,

--- a/src/iam/interfaces/active-user.data.ts
+++ b/src/iam/interfaces/active-user.data.ts
@@ -1,4 +1,5 @@
 import { Role } from '../../users/enums/role.enum';
+import { PermissionType } from '../authorization/permission.type';
 
 export interface ActiveUserData {
   /**
@@ -13,4 +14,12 @@ export interface ActiveUserData {
   /**
    * The subject's (user) role*/
   role: Role;
+
+  /**
+   * The subject's (user) permissions.
+   * NOTE: Using this approach in combination with the "role-based" approach
+   * does not make sense. We have those two properties here ("role" and "permissions")
+   * just to showcase two alternative approaches.
+   */
+  permissions: PermissionType[];
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,5 +1,9 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { Role } from '../enums/role.enum';
+import {
+  Permission,
+  PermissionType,
+} from '../../iam/authorization/permission.type';
 
 @Entity()
 export class User {
@@ -14,4 +18,10 @@ export class User {
 
   @Column({ enum: Role, default: Role.Regular })
   role: Role;
+
+  // NOTE: Having the "permissions" column in combination with the "role"
+  // likely does not make sense. We use both in this EXAMPLE just to showcase
+  // two different approaches to authorization.
+  @Column({ enum: Permission, default: [], type: 'json' })
+  permissions: PermissionType[];
 }


### PR DESCRIPTION
- A claim is a name-value pair that represents what the subject can do, not what the subject is. 
- When implementing claims-based authorization, instead of defining a set of roles that can be assigned to users, we define multiple permissions and then have the ability to grant those permissions to individual users.
- In our application so far, we assumed that only users with the admin role can create, update, and delete coffees. 
- Claims-based authorization comes in handy when we need more granular control, and for example, want specific users to be able to create and update coffees, but only 1 specific supervisor user has the capability of deleting coffees.